### PR TITLE
Change rocketinsights to project-hamilton

### DIFF
--- a/Formula/tgenv.rb
+++ b/Formula/tgenv.rb
@@ -1,9 +1,9 @@
 class Tgenv < Formula
   desc "Terragrunt version manager inspired by tfenv"
-  homepage "https://github.com/rocketinsights/tgenv"
-  url "https://github.com/rocketinsights/tgenv/archive/v0.0.8.tar.gz"
+  homepage "https://github.com/project-hamilton/tgenv"
+  url "https://github.com/project-hamilton/tgenv/archive/v0.0.8.tar.gz"
   sha256 "13790b71c0f7fbdc48ca22a794481ac443faabd9e9facba4639b0f6cc19d674f"
-  head "https://github.com/rocketinsights/tgenv.git"
+  head "https://github.com/project-hamilton/tgenv.git"
 
   bottle :unneeded
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Homebrew tap for the Terragrunt version manager (tgenv) formula.
 
 ## How do I install this formula?
 
-First `brew tap rocketinsights/tgenv`.  This will setup the tap to access the formula in this repository.
+First `brew tap project-hamilton/tgenv`.  This will setup the tap to access the formula in this repository.
 
 If you already have Terragrunt installed via Homebrew, then you need to unlink the existing install as it will conflict with tgenv, `brew unlink terragrunt`.
 
@@ -16,4 +16,4 @@ For the latest Terragrunt release, `tgenv install latest`.
 
 For a specific Terragrunt release, `tgenv install 0.18.6` (replace "0.18.6" with whatever release you're aiming for).
 
-See our [tgenv repo](https://github.com/rocketinsights/tgenv) for additional information on the use of tgenv.
+See our [tgenv repo](https://github.com/project-hamilton/tgenv) for additional information on the use of tgenv.


### PR DESCRIPTION
This repo was forked from rocketinsights/tgenv so we needed to update the README.

Addresses https://github.com/project-hamilton/devops-board/issues/83

