### PR TITLE
rm  bottle :unneeded command due to deprecation

### DIFF
--- a/Formula/tgenv.rb
+++ b/Formula/tgenv.rb
@@ -5,8 +5,6 @@ class Tgenv < Formula
   sha256 "13790b71c0f7fbdc48ca22a794481ac443faabd9e9facba4639b0f6cc19d674f"
   head "https://github.com/project-hamilton/tgenv.git"
 
-  bottle :unneeded
-
   conflicts_with "terragrunt", :because => "tgenv symlinks terragrunt binaries"
 
   def install


### PR DESCRIPTION
The `bottle :unneeded` command has been deprecated and now been deprecated and triggers an [error](https://github.com/project-hamilton/cbdc-terraform-hamilton-live/runs/5466989012?check_suite_focus=true).

[reference](https://stackoverflow.com/a/45163490)